### PR TITLE
Fixing second pseudoatom index in force field json output.

### DIFF
--- a/src/raspakit/forcefield/forcefield.cpp
+++ b/src/raspakit/forcefield/forcefield.cpp
@@ -542,7 +542,7 @@ nlohmann::json ForceField::jsonForceFieldStatus() const
       {
         case VDWParameters::Type::LennardJones:
           interactions[count]["typeA"] = pseudoAtoms[i].name;
-          interactions[count]["typeB"] = pseudoAtoms[i].name;
+          interactions[count]["typeB"] = pseudoAtoms[j].name;
           interactions[count]["potential"] = "Lennard-Jones";
           interactions[count]["ε/kʙ [K]"] = data[i * numberOfPseudoAtoms + j].parameters.x * Units::EnergyToKelvin;
           interactions[count]["σ/kʙ [Å]"] = data[i * numberOfPseudoAtoms + j].parameters.y;


### PR DESCRIPTION
Hello,

thank you for developing sharing such a great software package.

When checking the output I noticed that the second pseudoatom index in the force field is set wrongly to the first index in the json output file. This PR should fix this.