### PR TITLE
Fixing binary restart-file parser  

### DIFF
--- a/src/raspakit/running_energy.cpp
+++ b/src/raspakit/running_energy.cpp
@@ -328,6 +328,7 @@ Archive<std::ifstream> &operator>>(Archive<std::ifstream> &archive, RunningEnerg
   archive >> e.dudlambdaCharge;
   archive >> e.dudlambdaEwald;
   archive >> e.translationalKineticEnergy;
+  archive >> e.rotationalKineticEnergy;
   archive >> e.NoseHooverEnergy;
 
   return archive;


### PR DESCRIPTION
It seems that the ``rotationalKineticEnergy`` variable was not read out from the restart binary file in ``running_energy.cpp`` making it impossible to restart calculations. This PR should fix this.